### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Learn to write faster code by experimenting with this library 
 
-#pip install pythonbenchmark  
+# pip install pythonbenchmark  
 - The timeit module that comes with python is only useful for small bits of Python code not for functions.
 
 - This library solves that. It provides an intuitive way to measure the execution time of functions and compare the relative speed of two functions.
@@ -18,7 +18,7 @@ def myFunction(something):
     [x*x for x in range(1000000)]
 ```
 
-###How-To:
+### How-To:
 A typical use case is: I have functionX, and optimized functionX. Now I want to know if my modified version is faster and how much.
 
 ```python


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
